### PR TITLE
Detect Huawei Mate 40 and Mate 40 Pro

### DIFF
--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -493,7 +493,7 @@
             ], [MODEL, [VENDOR, 'HTC'], [TYPE, TABLET]], [
 
             /d\/huawei([\w\s-]+)[;\)]/i,                                        // Huawei
-            /android.+\s(nexus\s6p|vog-[at]?l\d\d|ane-[at]?l[x\d]\d|eml-a?l\d\da?|lya-[at]?l\d[\dc]|clt-a?l\d\di?|ele-[at]?l\d\d|yale?\-a?l\d{2}[ad]?)/i
+            /android.+\s(nexus\s6p|vog-[at]?l\d\d|ane-[at]?l[x\d]\d|eml-a?l\d\da?|lya-[at]?l\d[\dc]|clt-a?l\d\di?|ele-[at]?l\d\d|noh-\w{2}\d+|oce-\w{2}\d+|yale?\-a?l\d{2}[ad]?)/i
             ], [MODEL, [VENDOR, 'Huawei'], [TYPE, MOBILE]], [
 
             /android.+(bah2?-a?[lw]\d{2})/i                                     // Huawei MediaPad

--- a/test/device-test.json
+++ b/test/device-test.json
@@ -1224,6 +1224,33 @@
       }
     },
     {
+      "desc": "Huawei Mate 40",
+      "ua": "Mozilla/5.0 (Linux; Android 10; OCE-AN10; HMSCore 5.1.1.303) AppleWebkit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 HuaweiBrowser/11.0.5.306 Mobile Safari/537.36",
+      "expect": {
+          "vendor": "Huawei",
+          "model": "OCE-AN10",
+          "type": "mobile"
+      }
+    },
+    {
+      "desc": "Huawei Mate 40 Pro",
+      "ua": "Mozilla/5.0 (Linux; Android 10; NOH-NX9; HMSCore 5.1.1.303) AppleWebkit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 HuaweiBrowser/11.0.5.306 Mobile Safari/537.36",
+      "expect": {
+          "vendor": "Huawei",
+          "model": "NOH-NX9",
+          "type": "mobile"
+      }
+    },
+    {
+      "desc": "Huawei Mate 40 Pro",
+      "ua": "Mozilla/5.0 (Linux; Android 10; NOH-AN00; HMSCore 5.1.1.303) AppleWebkit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 HuaweiBrowser/11.0.5.306 Mobile Safari/537.36",
+      "expect": {
+          "vendor": "Huawei",
+          "model": "NOH-AN00",
+          "type": "mobile"
+      }
+    },
+    {
         "desc": "Huawei P20 Lite",
         "ua": "Mozilla/5.0 (Linux; Android 8.0.0; ANE-LX1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36",
         "expect": {


### PR DESCRIPTION
Mate 40 Pro models per https://www.gsmchoice.com/en/catalogue/huawei/mate40pro/ :
`NOH-NX9`
`NOH-AN00`

Mate 40 models per https://www.gsmchoice.com/en/catalogue/huawei/mate40/ :
`OCE-AN10`

Regex validation: https://regex101.com/r/PSnazK/1

Test 1:

Passes: `jshint src/ua-parser.js && mocha -R nyan test/test.js`

Test 2: 
```
var UAParser = require('ua-parser-js');

console.log('Mate40 Pro:')
const uastring1 = "Mozilla/5.0 (Linux; Android 10; NOH-NX9; HMSCore 5.1.1.303) AppleWebkit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 HuaweiBrowser/11.0.5.306 Mobile Safari/537.36"
console.log(UAParser(uastring1))

console.log('Mate40 Pro:')
const uastring2 = "Mozilla/5.0 (Linux; Android 10; NOH-AN00; HMSCore 5.1.1.303) AppleWebkit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 HuaweiBrowser/11.0.5.306 Mobile Safari/537.36"
console.log(UAParser(uastring2))

console.log('Mate40:')
const uastring3 = "Mozilla/5.0 (Linux; Android 10; OCE-AN10; HMSCore 5.1.1.303) AppleWebkit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 HuaweiBrowser/11.0.5.306 Mobile Safari/537.36"
console.log(UAParser(uastring3))
```

Before:

<pre><code>
Mate40 Pro:
{
  ua: 'Mozilla/5.0 (Linux; Android 10; NOH-NX9; HMSCore 5.1.1.303) AppleWebkit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 HuaweiBrowser/11.0.5.306 Mobile Safari/537.36',
  browser: { name: 'Chrome', version: '83.0.4103.106', major: '83' },
  engine: { name: 'Blink', version: '83.0.4103.106' },
  os: { name: 'Android', version: '10' },
  device: { <b>vendor: undefined, model: 'HMSCore 5.1.1.303', type: 'mobile'</b> },
  cpu: { architecture: undefined }
}
Mate40 Pro:
{
  ua: 'Mozilla/5.0 (Linux; Android 10; NOH-AN00; HMSCore 5.1.1.303) AppleWebkit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 HuaweiBrowser/11.0.5.306 Mobile Safari/537.36',
  browser: { name: 'Chrome', version: '83.0.4103.106', major: '83' },
  engine: { name: 'Blink', version: '83.0.4103.106' },
  os: { name: 'Android', version: '10' },
  device: { <b>vendor: undefined, model: 'HMSCore 5.1.1.303', type: 'mobile'</b> },
  cpu: { architecture: undefined }
}
Mate40:
{
  ua: 'Mozilla/5.0 (Linux; Android 10; OCE-AN10; HMSCore 5.1.1.303) AppleWebkit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 HuaweiBrowser/11.0.5.306 Mobile Safari/537.36',
  browser: { name: 'Chrome', version: '83.0.4103.106', major: '83' },
  engine: { name: 'Blink', version: '83.0.4103.106' },
  os: { name: 'Android', version: '10' },
  device: { <b>vendor: undefined, model: 'HMSCore 5.1.1.303', type: 'mobile'</b> },
  cpu: { architecture: undefined }
}
</code></pre>

After:

<pre><code>
Mate40 Pro:
{
  ua: 'Mozilla/5.0 (Linux; Android 10; NOH-NX9; HMSCore 5.1.1.303) AppleWebkit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 HuaweiBrowser/11.0.5.306 Mobile Safari/537.36',
  browser: { name: 'Chrome', version: '83.0.4103.106', major: '83' },
  engine: { name: 'Blink', version: '83.0.4103.106' },
  os: { name: 'Android', version: '10' },
  device: { <b>vendor: 'Huawei', model: 'NOH-NX9', type: 'mobile'</b> },
  cpu: { architecture: undefined }
}
Mate40 Pro:
{
  ua: 'Mozilla/5.0 (Linux; Android 10; NOH-AN00; HMSCore 5.1.1.303) AppleWebkit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 HuaweiBrowser/11.0.5.306 Mobile Safari/537.36',
  browser: { name: 'Chrome', version: '83.0.4103.106', major: '83' },
  engine: { name: 'Blink', version: '83.0.4103.106' },
  os: { name: 'Android', version: '10' },
  device: { <b>vendor: 'Huawei', model: 'NOH-AN00', type: 'mobile'</b> },
  cpu: { architecture: undefined }
}
Mate40:
{
  ua: 'Mozilla/5.0 (Linux; Android 10; OCE-AN10; HMSCore 5.1.1.303) AppleWebkit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 HuaweiBrowser/11.0.5.306 Mobile Safari/537.36',
  browser: { name: 'Chrome', version: '83.0.4103.106', major: '83' },
  engine: { name: 'Blink', version: '83.0.4103.106' },
  os: { name: 'Android', version: '10' },
  device: { <b>vendor: 'Huawei', model: 'OCE-AN10', type: 'mobile'</b> },
  cpu: { architecture: undefined }
}

</code></pre>